### PR TITLE
change select to mimic ct_select_u32 behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,15 +283,20 @@ Secret-dependent loop bounds are a special case of this problem.
 Timing leaks may be mitigated by introducing dummy operations in branches of the program in order to ensure a constant execution time. It is however more reliable to avoid branchings altogether, for example by implementing the conditional operation as a straight-line program. To select between two inputs `a` and `b` depending on a selection bit `bit`, this can be achieved with the following code:
 <!-- from E. Kasper's ECC code, listing 1 in http://static.googleusercontent.com/external_content/untrusted_dlcp/research.google.com/en//pubs/archive/37376.pdf -->
 <!-- Changed int to unsigned. The C standard guarantees that negation of an n-bit unsigned x is 2^n - x; signed integers may have other interpretations, e.g. one's complement -->
+<!-- Changed to return a when bit is non-zero, b otherwise. -->
+
 
 ```C
-unsigned select (unsigned a, unsigned b, unsigned bit) 
+/* Conditionally return a or b depending on whether bit is set */
+/* Equivalent to: return bit ? a : b */
+unsigned select (unsigned a, unsigned b, unsigned bit)
 {
-    /* -0 = 0, -1 = 0xff....ff */
-    unsigned mask = - bit;
-    unsigned ret = mask & (a^b);
-    ret = ret ^ a;
-    return ret;
+        unsigned isnonzero = (bit | -bit) >> (sizeof(unsigned) * 8 - 1);
+        /* -0 = 0, -1 = 0xff....ff */
+        unsigned mask = -isnonzero;
+        unsigned ret = mask & (b^a);
+        ret = ret ^ b;
+        return ret;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Timing leaks may be mitigated by introducing dummy operations in branches of the
 /* Equivalent to: return bit ? a : b */
 unsigned select (unsigned a, unsigned b, unsigned bit)
 {
-        unsigned isnonzero = (bit | -bit) >> (sizeof(unsigned) * 8 - 1);
+        unsigned isnonzero = (bit | -bit) >> (sizeof(unsigned) * CHAR_BIT - 1);
         /* -0 = 0, -1 = 0xff....ff */
         unsigned mask = -isnonzero;
         unsigned ret = mask & (b^a);


### PR DESCRIPTION
Before this patch, it was not explicit that `a` was returned when `bit` was zero and `b` was returned when `bit` was one. This patch make `select` behave consistently with respect to `ct_select_u32` by returning `a` when `bit` is zero and `b` otherwise.

I believe consistency between implementations presented by this document is more important than sticking to E. Kasper's ECC code. In fact, it is already different as the comments show (changed `int` to `unsigned`).

To illustrate, consider the output of [this program](https://gist.github.com/kAworu/f832e373814c5805a18643245fd96c27) that show returned values from `select`, the proposed change from this PR, and `ct_select_u32`:

```
---
select       ('a', 'b', 0)=a
proposed     ('a', 'b', 0)=b
ct_select_u32('a', 'b', 0)=b
---
select       ('a', 'b', 1)=b
proposed     ('a', 'b', 1)=a
ct_select_u32('a', 'b', 1)=a
---
select       ('a', 'b', 2)=c
proposed     ('a', 'b', 2)=a
ct_select_u32('a', 'b', 2)=a
```

On a side note, I would even consider changing the signatures to

```c
unsigned select(unsigned bit, unsigned a, unsigned b)
```

so that the argument order match exactly the ternary operator order. That way, it could be renamed something like `timingsafe_ternary()` which in my opinion would follow the principle of least astonishment.