### PR TITLE
docs: fix typo in README.md (occured -> occurred)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ A possibly faster solution on Intel processors involves the [CMOV](http://www.ja
 
 ### Problem
 
-The access time of a table element can vary with its index (depending for example on whether a cache-miss has occured). This has for example been exploited in a series of cache-timing attacks on AES.
+The access time of a table element can vary with its index (depending for example on whether a cache-miss has occurred). This has for example been exploited in a series of cache-timing attacks on AES.
 
 ### Solution
 


### PR DESCRIPTION
Small docs fix: corrected "occured" to "occurred" in the constant-time table-lookup section of the README. Docs-only, no content change.